### PR TITLE
[acl]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.grep?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # acl
 
 Commands for Manipulating POSIX Access Control Lists.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# acl
+
+Commands for Manipulating POSIX Access Control Lists.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*
+
+# Testing
+
+To run tests follow the example in the latest [test standards document](https://github.com/habitat-sh/core-plans/blob/master/docs/dev/policy_documents/standards-for-tests.md).

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/getfacl'

--- a/controls/acl_exists.rb
+++ b/controls/acl_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm acl exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'acl')
+ 
+control 'core-plans-acl-exists' do
+  impact 1.0
+  title 'Ensure acl exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/getfacl')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/acl_works.rb
+++ b/controls/acl_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm acl works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'acl')
+
+control 'core-plans-acl-works' do
+  impact 1.0
+  title 'Ensure acl works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} getfacl --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /getfacl #{plan_pkg_version}/}
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: acl
+title: Habitat Core Plan acl
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan acl
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,41 @@
+pkg_name=acl
+pkg_origin=core
+pkg_version=2.2.53
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Commands for Manipulating POSIX Access Control Lists."
+pkg_upstream_url="https://savannah.nongnu.org/projects/acl"
+pkg_license=('lgpl')
+pkg_source="http://download.savannah.gnu.org/releases/$pkg_name/$pkg_name-${pkg_version}.tar.gz"
+pkg_shasum="06be9865c6f418d851ff4494e12406568353b891ffe1f596b34693c387af26c7"
+pkg_deps=(
+  core/glibc
+  core/attr
+)
+pkg_build_deps=(
+  core/diffutils
+  core/patch
+  core/make
+  core/file
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_install() {
+  make install
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,5 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "getfacl version matches ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" getfacl --version | awk '{print $2}')"
+  diff <(echo "$actual_version") <(echo "${expected_version}")
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://a11657ac026db1dcc1ef602a215ce073156fabd8b82896ede3423d4582b95309 --input-file /src/attributes.yml

Profile: Habitat Core Plan acl (acl)
Version: 0.1.0
Target:  docker://a11657ac026db1dcc1ef602a215ce073156fabd8b82896ede3423d4582b95309

  ✔  core-plans-acl-works: Ensure acl works as expected
     ✔  Command: `hab pkg path core/acl` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/acl` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/acl/2.2.53/20200603121344 getfacl --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/acl/2.2.53/20200603121344 getfacl --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/acl/2.2.53/20200603121344 getfacl --version` stdout is expected to match /getfacl 2.2.53/
     ✔  Command: `DEBUG=true; hab pkg exec core/acl/2.2.53/20200603121344 getfacl --version` stderr is expected to be empty
  ✔  core-plans-acl-exists: Ensure acl exists
     ✔  File /hab/pkgs/core/acl/2.2.53/20200603121344/bin/getfacl is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
```