### PR TITLE
version bump from 2.2.53 to 2.3.1

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=acl
 pkg_origin=core
-pkg_version=2.2.53
+pkg_version=2.3.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Commands for Manipulating POSIX Access Control Lists."
 pkg_upstream_url="https://savannah.nongnu.org/projects/acl"
 pkg_license=('lgpl')
 pkg_source="http://download.savannah.gnu.org/releases/$pkg_name/$pkg_name-${pkg_version}.tar.gz"
-pkg_shasum="06be9865c6f418d851ff4494e12406568353b891ffe1f596b34693c387af26c7"
+pkg_shasum="760c61c68901b37fdd5eefeeaf4c0c7a26bdfdd8ac747a1edff1ce0e243c11af"
 pkg_deps=(
   core/glibc
   core/attr


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4041
Signed-off-by: RaviDuddela <RaviShankar.Duddela@progress.com>